### PR TITLE
Altered birth and death date grammar to be more readable

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ would output:
 
 The parser is case insensitive. An example of an almost fully involved CANQL query is:
 
-> First 27 Male Liveborn Thames Cases Due between 20/06/2015 and 25/06/2015 were Born on 22/06/2015 and were Diead on 07/07/2015 with Prenatal Anomalies and Postnatal Tests and Missing Postcode and Date of Birth and Wait Action and Unprocessed paediatric records and Mother were Born between 01/10/1990 and 10/01/1999 and were Died on 01/08/2015 with Populated Postcode and NHS Number
+> First 27 Male Liveborn Thames Cases Due between 20/06/2015 and 25/06/2015 and Born on 22/06/2015 and that Died on 07/07/2015 with Prenatal Anomalies and Postnatal Tests and Missing Postcode and Date of Birth and Wait Action and Unprocessed paediatric records and Mother Born between 01/10/1990 and 10/01/1999 and who Died on 01/08/2015 with Populated Postcode and NHS Number
 
 Please see the tests for many more examples.
 

--- a/lib/canql/grammars/age.treetop
+++ b/lib/canql/grammars/age.treetop
@@ -1,15 +1,15 @@
 module Canql
   grammar Age
     rule with_birth_date
-      were_keyword born_keyword fuzzy_date <Nodes::Age::BirthDateNode>
+      born_keyword fuzzy_date <Nodes::Age::BirthDateNode>
     end
 
     rule with_death_date
-      were_keyword died_keyword fuzzy_date <Nodes::Age::DeathDateNode>
+      that_who_keyword? died_keyword fuzzy_date <Nodes::Age::DeathDateNode>
     end
 
-    rule were_keyword
-      space 'were' word_break
+    rule that_who_keyword
+      space ('that' / 'who') word_break
     end
 
     rule born_keyword

--- a/test/nodes/age_test.rb
+++ b/test/nodes/age_test.rb
@@ -3,63 +3,63 @@ require 'test_helper'
 # case anomaly tests
 class AgeTest < Minitest::Test
   def test_should_filter_by_case_birth_date_range
-    parser = Canql::Parser.new('all cases were born between 10/01/2000 and 10/10/2010')
+    parser = Canql::Parser.new('all cases born between 10/01/2000 and 10/10/2010')
     assert parser.valid?
     assert_equal({ Canql::LIMITS => ['2000-01-10', '2010-10-10'] },
                  parser.meta_data['patient.birthdate'])
   end
 
   def test_should_filter_by_case_exect_birth_date
-    parser = Canql::Parser.new('all cases were born on 10/01/2000')
+    parser = Canql::Parser.new('all cases born on 10/01/2000')
     assert parser.valid?
     assert_equal({ Canql::LIMITS => ['2000-01-10', '2000-01-10'] },
                  parser.meta_data['patient.birthdate'])
   end
 
   def test_should_filter_by_mothers_birth_date_range
-    parser = Canql::Parser.new('all cases with mother were born between 10/01/2000 and 10/10/2010')
+    parser = Canql::Parser.new('all cases with mother born between 10/01/2000 and 10/10/2010')
     assert parser.valid?
     assert_equal({ Canql::LIMITS => ['2000-01-10', '2010-10-10'] },
                  parser.meta_data['mother.birthdate'])
   end
 
   def test_should_filter_by_mothers_exect_birth_date
-    parser = Canql::Parser.new('all cases with mother were born on 10/01/2000')
+    parser = Canql::Parser.new('all cases with mother born on 10/01/2000')
     assert parser.valid?
     assert_equal({ Canql::LIMITS => ['2000-01-10', '2000-01-10'] },
                  parser.meta_data['mother.birthdate'])
   end
 
   def test_should_filter_by_case_death_date_range
-    parser = Canql::Parser.new('all cases were died between 10/01/2000 and 10/10/2010')
+    parser = Canql::Parser.new('all cases who died between 10/01/2000 and 10/10/2010')
     assert parser.valid?
     assert_equal({ Canql::LIMITS => ['2000-01-10', '2010-10-10'] },
                  parser.meta_data['patient.deathdate'])
   end
 
   def test_should_filter_by_case_exect_death_date
-    parser = Canql::Parser.new('all cases were died on 10/01/2000')
+    parser = Canql::Parser.new('all cases that died on 10/01/2000')
     assert parser.valid?
     assert_equal({ Canql::LIMITS => ['2000-01-10', '2000-01-10'] },
                  parser.meta_data['patient.deathdate'])
   end
 
   def test_should_filter_by_mothers_death_date_range
-    parser = Canql::Parser.new('all cases with mother were died between 10/01/2000 and 10/10/2010')
+    parser = Canql::Parser.new('all cases with mother that died between 10/01/2000 and 10/10/2010')
     assert parser.valid?
     assert_equal({ Canql::LIMITS => ['2000-01-10', '2010-10-10'] },
                  parser.meta_data['mother.deathdate'])
   end
 
   def test_should_filter_by_mothers_exect_death_date
-    parser = Canql::Parser.new('all cases with mother were died on 10/01/2000')
+    parser = Canql::Parser.new('all cases with mother who died on 10/01/2000')
     assert parser.valid?
     assert_equal({ Canql::LIMITS => ['2000-01-10', '2000-01-10'] },
                  parser.meta_data['mother.deathdate'])
   end
 
   def test_should_filter_by_case_combined_birth_and_death_date
-    parser = Canql::Parser.new('all cases were born between 10/01/2000 and 10/10/2010 and were died on 01/01/2015')
+    parser = Canql::Parser.new('all cases born between 10/01/2000 and 10/10/2010 and that died on 01/01/2015')
     assert parser.valid?
     assert_equal({ Canql::LIMITS => ['2000-01-10', '2010-10-10'] },
                  parser.meta_data['patient.birthdate'])
@@ -68,7 +68,7 @@ class AgeTest < Minitest::Test
   end
 
   def test_should_filter_by_mother_combined_birth_and_death_date
-    parser = Canql::Parser.new('all cases with mother were born between 10/01/2000 and 10/10/2010 and were died on 01/01/2015')
+    parser = Canql::Parser.new('all cases with mother born between 10/01/2000 and 10/10/2010 and that died on 01/01/2015')
     assert parser.valid?
     assert_equal({ Canql::LIMITS => ['2000-01-10', '2010-10-10'] },
                  parser.meta_data['mother.birthdate'])

--- a/test/parser_test.rb
+++ b/test/parser_test.rb
@@ -34,12 +34,12 @@ class ParserTest < Minitest::Test
   def test_should_combine_filters
     parser = Canql::Parser.new("first 27 male liveborn thames cases \
       expected between 20/06/2015 and 25/06/2015 \
-      were born on 22/06/2015 and were died on 01/12/2015 \
+      and born on 22/06/2015 and that died on 01/12/2015 \
       with prenatal anomalies \
       and postnatal tests and missing postcode and date of birth \
       and wait action and unprocessed paediatric records \
-      and mother were born between 01/10/1990 and 10/01/1999 \
-      and were died on 01/01/2016 \
+      and mother born between 01/10/1990 and 10/01/1999 \
+      and who died on 01/01/2016 \
       with fields postcode and nhs number")
     assert parser.valid?
     assert_equal 17, parser.meta_data.count
@@ -71,12 +71,12 @@ class ParserTest < Minitest::Test
       'all cases with mother with fields postcode and nhs number',
       'all cases with mother with populated postcode and nhs number',
       'all cases with wait action and unprocessed paediatric records',
-      'all cases were born on 22/06/2015',
-      'all babies were born on 22/06/2015',
-      'all cases with mother were born between 01/10/1990 and 10/01/1999',
-      'all babies with mother were born between 01/10/1990 and 10/01/1999',
-      'all cases with mother were died on 01/01/2016',
-      'all cases were died on 01/12/2015'
+      'all cases born on 22/06/2015',
+      'all babies born on 22/06/2015',
+      'all cases with mother born between 01/10/1990 and 10/01/1999',
+      'all babies with mother born between 01/10/1990 and 10/01/1999',
+      'all cases with mother that died on 01/01/2016',
+      'all cases who died on 01/12/2015'
     ]
     assert_meta_data_includes(parser, individual_queries)
   end


### PR DESCRIPTION
Altered birth and death date grammar to be more readable and corrected typo on README.  The born clause no longer requires the prefixed 'were' and the dead clause can be prefixed with 'that' or 'who'.