### PR TITLE
Dev/5302 icd codes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,8 @@ Rails:
   Enabled: false
 
 AllCops:
-  TargetRubyVersion: 2.3
+  TargetRailsVersion: 4.2
+  TargetRubyVersion: 2.4
 
 Style/FrozenStringLiteralComment:
   Enabled: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: ruby
 
 rvm:
-  - 2.3.6
-  - 2.4.3
-  - 2.5.0
+  - 2.3
+  - 2.4
+  - 2.5
 
 sudo: false
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ would output:
 
 The parser is case insensitive. An example of an almost fully involved CANQL query is:
 
-> First 27 Male Liveborn Thames Cases Due between 20/06/2015 and 25/06/2015 and Born on 22/06/2015 and that Died on 07/07/2015 with Prenatal Anomalies and Postnatal Tests and Missing Postcode and Date of Birth and QA Action and Unprocessed paediatric records and Mother Born between 01/10/1990 and 10/01/1999 and who Died on 01/08/2015 with Populated Postcode and NHS Number
+> First 27 Male Liveborn Thames Cases Due between 20/06/2015 and 25/06/2015 and Born on 22/06/2015 and that Died on 07/07/2015 with Prenatal Suspected Q20 Anomalies and Postnatal Tests and Missing Postcode and Date of Birth and QA Action and Unprocessed paediatric records and Mother Born between 01/10/1990 and 10/01/1999 and who Died on 01/08/2015 with Populated Postcode and NHS Number
 
 Please see the tests for many more examples.
 

--- a/canql.gemspec
+++ b/canql.gemspec
@@ -23,11 +23,12 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
+  spec.add_dependency 'rails', '>= 4.1', '< 6'
   spec.add_dependency 'ndr_support', '>= 3.0', '< 6'
   spec.add_dependency 'treetop', '>= 1.4.10'
   spec.add_dependency 'chronic', '~> 0.3.0'
 
-  spec.add_development_dependency 'ndr_dev_support', '~> 2.0', '>= 2.0.2'
+  spec.add_development_dependency 'ndr_dev_support', '>= 3.0', '<6'
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'minitest'

--- a/lib/canql/grammars/anomaly.treetop
+++ b/lib/canql/grammars/anomaly.treetop
@@ -1,7 +1,7 @@
 module Canql
   grammar Anomaly
     rule anomalies
-      and_keyword? existance_modifier:anomalies_no_keyword? natal_period:anomalies_natal_period? anomalies_keyword <Nodes::Anomaly::Exists>
+      and_keyword? existance_modifier:anomalies_no_keyword? status_type:anomaly_status? natal_period:anomalies_natal_period? code_data:(space first:anomalies_icd_code rest:more_anomalies_icd_codes* word_break)? anomalies_keyword <Nodes::Anomaly::Exists>
     end
 
     rule anomalies_no_keyword
@@ -12,8 +12,24 @@ module Canql
       (prenatal_keyword / postnatal_keyword)
     end
 
+    rule anomaly_status
+      (suspected_keyword / confirmed_keyword / probable_keyword)
+    end
+
     rule anomalies_keyword
       space 'anomalies' word_break
+    end
+
+    rule more_anomalies_icd_codes
+      ','? space? ('and' space)? anomalies_icd_code <Nodes::Anomaly::AdditionalIcdCodeNode>
+    end
+
+    rule anomalies_icd_code
+      icd_code_name <Nodes::Anomaly::SingleIcdCodeNode>
+    end
+
+    rule icd_code_name
+      [a-z] [0-9] 1..3
     end
   end
 end

--- a/lib/canql/grammars/main.treetop
+++ b/lib/canql/grammars/main.treetop
@@ -80,6 +80,18 @@ grammar Canql
     space 'postnatal' word_break
   end
 
+  rule suspected_keyword
+    space 'suspected' word_break
+  end
+
+  rule confirmed_keyword
+    space 'confirmed' word_break
+  end
+
+  rule probable_keyword
+    space 'probable' word_break
+  end
+
   rule with_conditions
      anomalies / test_results / patient_field_existance / mother_conditions / action_or_ebr
   end

--- a/lib/canql/nodes/anomaly.rb
+++ b/lib/canql/nodes/anomaly.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Canql #:nodoc: all
   module Nodes
     module Anomaly
@@ -10,12 +11,50 @@ module Canql #:nodoc: all
           ".#{text_value}"
         end
 
+        def anomaly_status_type
+          text_value = status_type.text_value.strip
+          return '' if '' == text_value
+
+          ".#{text_value}"
+        end
+
+        def anomaly_qualifier
+          anomaly_status_type + anomaly_type
+        end
+
         def meta_data_item
+          existance_filter.merge(code_filter)
+        end
+
+        def existance_filter
           {
-            "anomaly#{anomaly_type}.exists" => {
+            "anomaly#{anomaly_qualifier}.exists" => {
               Canql::EQUALS => existance_modifier.text_value.strip != 'no'
             }
           }
+        end
+
+        def code_filter
+          return {} if code_data.text_value.blank?
+          code_array = [code_data.first.to_code]
+          code_data.rest.elements.map do |e|
+            code_array << e.to_code if !e.nil? && e.respond_to?(:to_code)
+          end
+          code_array.flatten.delete_if { |a| a.nil? || a.empty? }
+
+          { "anomaly#{anomaly_qualifier}.icd_code" => { Canql::BEGINS => code_array } }
+        end
+      end
+
+      module AdditionalIcdCodeNode
+        def to_code
+          anomalies_icd_code.to_code
+        end
+      end
+
+      module SingleIcdCodeNode
+        def to_code
+          text_value.upcase
         end
       end
     end

--- a/lib/canql/nodes/anomaly.rb
+++ b/lib/canql/nodes/anomaly.rb
@@ -37,10 +37,10 @@ module Canql #:nodoc: all
         def code_filter
           return {} if code_data.text_value.blank?
           code_array = [code_data.first.to_code]
-          code_data.rest.elements.map do |e|
-            code_array << e.to_code if !e.nil? && e.respond_to?(:to_code)
+          code_data.rest.elements.each do |code|
+            code_array << code.try(:to_code)
           end
-          code_array.flatten.delete_if { |a| a.nil? || a.empty? }
+          code_array.flatten.delete_if(&:blank?)
 
           { "anomaly#{anomaly_qualifier}.icd_code" => { Canql::BEGINS => code_array } }
         end

--- a/lib/canql/nodes/anomaly.rb
+++ b/lib/canql/nodes/anomaly.rb
@@ -40,7 +40,8 @@ module Canql #:nodoc: all
           code_data.rest.elements.each do |code|
             code_array << code.try(:to_code)
           end
-          code_array.flatten.delete_if(&:blank?)
+          code_array.flatten!
+          code_array.delete_if(&:blank?)
 
           { "anomaly#{anomaly_qualifier}.icd_code" => { Canql::BEGINS => code_array } }
         end

--- a/test/nodes/anomaly_test.rb
+++ b/test/nodes/anomaly_test.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'test_helper'
 
 # case anomaly tests
@@ -29,6 +30,12 @@ class AnomalyTest < Minitest::Test
 
   def test_should_filter_by_no_postnatal_anomaly
     parser = Canql::Parser.new('all cases with no postnatal anomalies')
+    assert parser.valid?
+    assert_equal({ Canql::EQUALS => false }, parser.meta_data['anomaly.postnatal.exists'])
+  end
+
+  def test_should_filter_by_no_postnatal_anomaly_and_prenatal_anomalies
+    parser = Canql::Parser.new('all cases with no postnatal anomalies and prenatal anomalies')
     assert parser.valid?
     assert_equal({ Canql::EQUALS => false }, parser.meta_data['anomaly.postnatal.exists'])
   end

--- a/test/nodes/anomaly_test.rb
+++ b/test/nodes/anomaly_test.rb
@@ -38,6 +38,7 @@ class AnomalyTest < Minitest::Test
     parser = Canql::Parser.new('all cases with no postnatal anomalies and prenatal anomalies')
     assert parser.valid?
     assert_equal({ Canql::EQUALS => false }, parser.meta_data['anomaly.postnatal.exists'])
+    assert_equal({ Canql::EQUALS => true }, parser.meta_data['anomaly.prenatal.exists'])
   end
 
   def test_should_filter_by_no_prenatal_anomaly

--- a/test/nodes/code_test.rb
+++ b/test/nodes/code_test.rb
@@ -1,0 +1,458 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+# case anomaly code tests
+class CodeTest < Minitest::Test
+  def test_should_filter_by_sigle_code
+    parser = Canql::Parser.new('all cases with q2 anomalies')
+    assert parser.valid?
+    assert_equal({ Canql::EQUALS => true }, parser.meta_data['anomaly.exists'])
+    assert_equal({ Canql::BEGINS => ['Q2'] }, parser.meta_data['anomaly.icd_code'])
+  end
+
+  def test_should_filter_by_multiple_codes_v1
+    parser = Canql::Parser.new('all cases with q2 and q3 anomalies')
+    assert parser.valid?
+    assert_equal({ Canql::EQUALS => true }, parser.meta_data['anomaly.exists'])
+    assert_equal({ Canql::BEGINS => %w[Q2 Q3] }, parser.meta_data['anomaly.icd_code'])
+  end
+
+  def test_should_filter_by_multiple_codes_v2
+    parser = Canql::Parser.new('all cases with q2, q3 anomalies')
+    assert parser.valid?
+    assert_equal({ Canql::EQUALS => true }, parser.meta_data['anomaly.exists'])
+    assert_equal({ Canql::BEGINS => %w[Q2 Q3] }, parser.meta_data['anomaly.icd_code'])
+  end
+
+  def test_should_filter_by_multiple_codes_v3
+    parser = Canql::Parser.new('all cases with q1, q2 and q3 anomalies')
+    assert parser.valid?
+    assert_equal({ Canql::EQUALS => true }, parser.meta_data['anomaly.exists'])
+    assert_equal({ Canql::BEGINS => %w[Q1 Q2 Q3] }, parser.meta_data['anomaly.icd_code'])
+  end
+
+  def test_should_filter_by_sigle_prenatal_code
+    parser = Canql::Parser.new('all cases with prenatal q2 anomalies')
+    assert parser.valid?
+    assert_equal({ Canql::EQUALS => true }, parser.meta_data['anomaly.prenatal.exists'])
+    assert_equal({ Canql::BEGINS => ['Q2'] }, parser.meta_data['anomaly.prenatal.icd_code'])
+  end
+
+  def test_should_filter_by_multiple_prenatal_codes_v1
+    parser = Canql::Parser.new('all cases with prenatal q2 and q3 anomalies')
+    assert parser.valid?
+    assert_equal({ Canql::EQUALS => true }, parser.meta_data['anomaly.prenatal.exists'])
+    assert_equal({ Canql::BEGINS => %w[Q2 Q3] }, parser.meta_data['anomaly.prenatal.icd_code'])
+  end
+
+  def test_should_filter_by_multiple_prenatal_codes_v2
+    parser = Canql::Parser.new('all cases with prenatal q2, q3 anomalies')
+    assert parser.valid?
+    assert_equal({ Canql::EQUALS => true }, parser.meta_data['anomaly.prenatal.exists'])
+    assert_equal({ Canql::BEGINS => %w[Q2 Q3] }, parser.meta_data['anomaly.prenatal.icd_code'])
+  end
+
+  def test_should_filter_by_multiple_prenatal_codes_v3
+    parser = Canql::Parser.new('all cases with prenatal q1, q2 and q3 anomalies')
+    assert parser.valid?
+    assert_equal({ Canql::EQUALS => true }, parser.meta_data['anomaly.prenatal.exists'])
+    assert_equal({ Canql::BEGINS => %w[Q1 Q2 Q3] }, parser.meta_data['anomaly.prenatal.icd_code'])
+  end
+
+  def test_should_filter_by_sigle_postnatal_code
+    parser = Canql::Parser.new('all cases with postnatal q2 anomalies')
+    assert parser.valid?
+    assert_equal({ Canql::EQUALS => true }, parser.meta_data['anomaly.postnatal.exists'])
+    assert_equal({ Canql::BEGINS => ['Q2'] }, parser.meta_data['anomaly.postnatal.icd_code'])
+  end
+
+  def test_should_filter_by_multiple_postnatal_codes_v1
+    parser = Canql::Parser.new('all cases with postnatal q2 and q3 anomalies')
+    assert parser.valid?
+    assert_equal({ Canql::EQUALS => true }, parser.meta_data['anomaly.postnatal.exists'])
+    assert_equal({ Canql::BEGINS => %w[Q2 Q3] }, parser.meta_data['anomaly.postnatal.icd_code'])
+  end
+
+  def test_should_filter_by_multiple_postnatal_codes_v2
+    parser = Canql::Parser.new('all cases with postnatal q2, q3 anomalies')
+    assert parser.valid?
+    assert_equal({ Canql::EQUALS => true }, parser.meta_data['anomaly.postnatal.exists'])
+    assert_equal({ Canql::BEGINS => %w[Q2 Q3] }, parser.meta_data['anomaly.postnatal.icd_code'])
+  end
+
+  def test_should_filter_by_multiple_postnatal_codes_v3
+    parser = Canql::Parser.new('all cases with postnatal q1, q2 and q3 anomalies')
+    assert parser.valid?
+    assert_equal({ Canql::EQUALS => true }, parser.meta_data['anomaly.postnatal.exists'])
+    assert_equal({ Canql::BEGINS => %w[Q1 Q2 Q3] }, parser.meta_data['anomaly.postnatal.icd_code'])
+  end
+
+  def test_should_filter_by_sigle_suspected_code
+    parser = Canql::Parser.new('all cases with suspected q2 anomalies')
+    assert parser.valid?
+    assert_equal({ Canql::EQUALS => true }, parser.meta_data['anomaly.suspected.exists'])
+    assert_equal({ Canql::BEGINS => ['Q2'] }, parser.meta_data['anomaly.suspected.icd_code'])
+  end
+
+  def test_should_filter_by_multiple_suspected_codes_v1
+    parser = Canql::Parser.new('all cases with suspected q2 and q3 anomalies')
+    assert parser.valid?
+    assert_equal({ Canql::EQUALS => true }, parser.meta_data['anomaly.suspected.exists'])
+    assert_equal({ Canql::BEGINS => %w[Q2 Q3] }, parser.meta_data['anomaly.suspected.icd_code'])
+  end
+
+  def test_should_filter_by_multiple_suspected_codes_v2
+    parser = Canql::Parser.new('all cases with suspected q2, q3 anomalies')
+    assert parser.valid?
+    assert_equal({ Canql::EQUALS => true }, parser.meta_data['anomaly.suspected.exists'])
+    assert_equal({ Canql::BEGINS => %w[Q2 Q3] }, parser.meta_data['anomaly.suspected.icd_code'])
+  end
+
+  def test_should_filter_by_multiple_suspected_codes_v3
+    parser = Canql::Parser.new('all cases with suspected q1, q2 and q3 anomalies')
+    assert parser.valid?
+    assert_equal({ Canql::EQUALS => true }, parser.meta_data['anomaly.suspected.exists'])
+    assert_equal({ Canql::BEGINS => %w[Q1 Q2 Q3] }, parser.meta_data['anomaly.suspected.icd_code'])
+  end
+
+  def test_should_filter_by_sigle_suspected_prenatal_code
+    parser = Canql::Parser.new('all cases with suspected prenatal q2 anomalies')
+    assert parser.valid?
+    assert_equal({ Canql::EQUALS => true }, parser.meta_data['anomaly.suspected.prenatal.exists'])
+    assert_equal(
+      { Canql::BEGINS => ['Q2'] },
+      parser.meta_data['anomaly.suspected.prenatal.icd_code']
+    )
+  end
+
+  def test_should_filter_by_multiple_suspected_prenatal_codes_v1
+    parser = Canql::Parser.new('all cases with suspected prenatal q2 and q3 anomalies')
+    assert parser.valid?
+    assert_equal({ Canql::EQUALS => true }, parser.meta_data['anomaly.suspected.prenatal.exists'])
+    assert_equal(
+      { Canql::BEGINS => %w[Q2 Q3] },
+      parser.meta_data['anomaly.suspected.prenatal.icd_code']
+    )
+  end
+
+  def test_should_filter_by_multiple_suspected_prenatal_codes_v2
+    parser = Canql::Parser.new('all cases with suspected prenatal q2, q3 anomalies')
+    assert parser.valid?
+    assert_equal({ Canql::EQUALS => true }, parser.meta_data['anomaly.suspected.prenatal.exists'])
+    assert_equal(
+      { Canql::BEGINS => %w[Q2 Q3] },
+      parser.meta_data['anomaly.suspected.prenatal.icd_code']
+    )
+  end
+
+  def test_should_filter_by_multiple_suspected_prenatal_codes_v3
+    parser = Canql::Parser.new('all cases with suspected prenatal q1, q2 and q3 anomalies')
+    assert parser.valid?
+    assert_equal({ Canql::EQUALS => true }, parser.meta_data['anomaly.suspected.prenatal.exists'])
+    assert_equal(
+      { Canql::BEGINS => %w[Q1 Q2 Q3] },
+      parser.meta_data['anomaly.suspected.prenatal.icd_code']
+    )
+  end
+
+  def test_should_filter_by_sigle_suspected_postnatal_code
+    parser = Canql::Parser.new('all cases with suspected postnatal q2 anomalies')
+    assert parser.valid?
+    assert_equal({ Canql::EQUALS => true }, parser.meta_data['anomaly.suspected.postnatal.exists'])
+    assert_equal(
+      { Canql::BEGINS => ['Q2'] },
+      parser.meta_data['anomaly.suspected.postnatal.icd_code']
+    )
+  end
+
+  def test_should_filter_by_multiple_suspected_postnatal_codes_v1
+    parser = Canql::Parser.new('all cases with suspected postnatal q2 and q3 anomalies')
+    assert parser.valid?
+    assert_equal({ Canql::EQUALS => true }, parser.meta_data['anomaly.suspected.postnatal.exists'])
+    assert_equal(
+      { Canql::BEGINS => %w[Q2 Q3] },
+      parser.meta_data['anomaly.suspected.postnatal.icd_code']
+    )
+  end
+
+  def test_should_filter_by_multiple_suspected_postnatal_codes_v2
+    parser = Canql::Parser.new('all cases with suspected postnatal q2, q3 anomalies')
+    assert parser.valid?
+    assert_equal({ Canql::EQUALS => true }, parser.meta_data['anomaly.suspected.postnatal.exists'])
+    assert_equal(
+      { Canql::BEGINS => %w[Q2 Q3] },
+      parser.meta_data['anomaly.suspected.postnatal.icd_code']
+    )
+  end
+
+  def test_should_filter_by_multiple_suspected_postnatal_codes_v3
+    parser = Canql::Parser.new('all cases with suspected postnatal q1, q2 and q3 anomalies')
+    assert parser.valid?
+    assert_equal({ Canql::EQUALS => true }, parser.meta_data['anomaly.suspected.postnatal.exists'])
+    assert_equal(
+      { Canql::BEGINS => %w[Q1 Q2 Q3] },
+      parser.meta_data['anomaly.suspected.postnatal.icd_code']
+    )
+  end
+
+  def test_should_filter_by_sigle_confirmed_code
+    parser = Canql::Parser.new('all cases with confirmed q2 anomalies')
+    assert parser.valid?
+    assert_equal({ Canql::EQUALS => true }, parser.meta_data['anomaly.confirmed.exists'])
+    assert_equal({ Canql::BEGINS => ['Q2'] }, parser.meta_data['anomaly.confirmed.icd_code'])
+  end
+
+  def test_should_filter_by_multiple_confirmed_codes_v1
+    parser = Canql::Parser.new('all cases with confirmed q2 and q3 anomalies')
+    assert parser.valid?
+    assert_equal({ Canql::EQUALS => true }, parser.meta_data['anomaly.confirmed.exists'])
+    assert_equal({ Canql::BEGINS => %w[Q2 Q3] }, parser.meta_data['anomaly.confirmed.icd_code'])
+  end
+
+  def test_should_filter_by_multiple_confirmed_codes_v2
+    parser = Canql::Parser.new('all cases with confirmed q2, q3 anomalies')
+    assert parser.valid?
+    assert_equal({ Canql::EQUALS => true }, parser.meta_data['anomaly.confirmed.exists'])
+    assert_equal({ Canql::BEGINS => %w[Q2 Q3] }, parser.meta_data['anomaly.confirmed.icd_code'])
+  end
+
+  def test_should_filter_by_multiple_confirmed_codes_v3
+    parser = Canql::Parser.new('all cases with confirmed q1, q2 and q3 anomalies')
+    assert parser.valid?
+    assert_equal({ Canql::EQUALS => true }, parser.meta_data['anomaly.confirmed.exists'])
+    assert_equal({ Canql::BEGINS => %w[Q1 Q2 Q3] }, parser.meta_data['anomaly.confirmed.icd_code'])
+  end
+
+  def test_should_filter_by_sigle_confirmed_prenatal_code
+    parser = Canql::Parser.new('all cases with confirmed prenatal q2 anomalies')
+    assert parser.valid?
+    assert_equal({ Canql::EQUALS => true }, parser.meta_data['anomaly.confirmed.prenatal.exists'])
+    assert_equal(
+      { Canql::BEGINS => ['Q2'] },
+      parser.meta_data['anomaly.confirmed.prenatal.icd_code']
+    )
+  end
+
+  def test_should_filter_by_multiple_confirmed_prenatal_codes_v1
+    parser = Canql::Parser.new('all cases with confirmed prenatal q2 and q3 anomalies')
+    assert parser.valid?
+    assert_equal({ Canql::EQUALS => true }, parser.meta_data['anomaly.confirmed.prenatal.exists'])
+    assert_equal(
+      { Canql::BEGINS => %w[Q2 Q3] },
+      parser.meta_data['anomaly.confirmed.prenatal.icd_code']
+    )
+  end
+
+  def test_should_filter_by_multiple_confirmed_prenatal_codes_v2
+    parser = Canql::Parser.new('all cases with confirmed prenatal q2, q3 anomalies')
+    assert parser.valid?
+    assert_equal({ Canql::EQUALS => true }, parser.meta_data['anomaly.confirmed.prenatal.exists'])
+    assert_equal(
+      { Canql::BEGINS => %w[Q2 Q3] },
+      parser.meta_data['anomaly.confirmed.prenatal.icd_code']
+    )
+  end
+
+  def test_should_filter_by_multiple_confirmed_prenatal_codes_v3
+    parser = Canql::Parser.new('all cases with confirmed prenatal q1, q2 and q3 anomalies')
+    assert parser.valid?
+    assert_equal({ Canql::EQUALS => true }, parser.meta_data['anomaly.confirmed.prenatal.exists'])
+    assert_equal(
+      { Canql::BEGINS => %w[Q1 Q2 Q3] },
+      parser.meta_data['anomaly.confirmed.prenatal.icd_code']
+    )
+  end
+
+  def test_should_filter_by_sigle_confirmed_postnatal_code
+    parser = Canql::Parser.new('all cases with confirmed postnatal q2 anomalies')
+    assert parser.valid?
+    assert_equal({ Canql::EQUALS => true }, parser.meta_data['anomaly.confirmed.postnatal.exists'])
+    assert_equal(
+      { Canql::BEGINS => ['Q2'] },
+      parser.meta_data['anomaly.confirmed.postnatal.icd_code']
+    )
+  end
+
+  def test_should_filter_by_multiple_confirmed_postnatal_codes_v1
+    parser = Canql::Parser.new('all cases with confirmed postnatal q2 and q3 anomalies')
+    assert parser.valid?
+    assert_equal({ Canql::EQUALS => true }, parser.meta_data['anomaly.confirmed.postnatal.exists'])
+    assert_equal(
+      { Canql::BEGINS => %w[Q2 Q3] },
+      parser.meta_data['anomaly.confirmed.postnatal.icd_code']
+    )
+  end
+
+  def test_should_filter_by_multiple_confirmed_postnatal_codes_v2
+    parser = Canql::Parser.new('all cases with confirmed postnatal q2, q3 anomalies')
+    assert parser.valid?
+    assert_equal({ Canql::EQUALS => true }, parser.meta_data['anomaly.confirmed.postnatal.exists'])
+    assert_equal(
+      { Canql::BEGINS => %w[Q2 Q3] },
+      parser.meta_data['anomaly.confirmed.postnatal.icd_code']
+    )
+  end
+
+  def test_should_filter_by_multiple_confirmed_postnatal_codes_v3
+    parser = Canql::Parser.new('all cases with confirmed postnatal q1, q2 and q3 anomalies')
+    assert parser.valid?
+    assert_equal({ Canql::EQUALS => true }, parser.meta_data['anomaly.confirmed.postnatal.exists'])
+    assert_equal(
+      { Canql::BEGINS => %w[Q1 Q2 Q3] },
+      parser.meta_data['anomaly.confirmed.postnatal.icd_code']
+    )
+  end
+
+  def test_should_filter_by_sigle_probable_code
+    parser = Canql::Parser.new('all cases with probable q2 anomalies')
+    assert parser.valid?
+    assert_equal({ Canql::EQUALS => true }, parser.meta_data['anomaly.probable.exists'])
+    assert_equal({ Canql::BEGINS => ['Q2'] }, parser.meta_data['anomaly.probable.icd_code'])
+  end
+
+  def test_should_filter_by_multiple_probable_codes_v1
+    parser = Canql::Parser.new('all cases with probable q2 and q3 anomalies')
+    assert parser.valid?
+    assert_equal({ Canql::EQUALS => true }, parser.meta_data['anomaly.probable.exists'])
+    assert_equal({ Canql::BEGINS => %w[Q2 Q3] }, parser.meta_data['anomaly.probable.icd_code'])
+  end
+
+  def test_should_filter_by_multiple_probable_codes_v2
+    parser = Canql::Parser.new('all cases with probable q2, q3 anomalies')
+    assert parser.valid?
+    assert_equal({ Canql::EQUALS => true }, parser.meta_data['anomaly.probable.exists'])
+    assert_equal({ Canql::BEGINS => %w[Q2 Q3] }, parser.meta_data['anomaly.probable.icd_code'])
+  end
+
+  def test_should_filter_by_multiple_probable_codes_v3
+    parser = Canql::Parser.new('all cases with probable q1, q2 and q3 anomalies')
+    assert parser.valid?
+    assert_equal({ Canql::EQUALS => true }, parser.meta_data['anomaly.probable.exists'])
+    assert_equal({ Canql::BEGINS => %w[Q1 Q2 Q3] }, parser.meta_data['anomaly.probable.icd_code'])
+  end
+
+  def test_should_filter_by_sigle_probable_prenatal_code
+    parser = Canql::Parser.new('all cases with probable prenatal q2 anomalies')
+    assert parser.valid?
+    assert_equal({ Canql::EQUALS => true }, parser.meta_data['anomaly.probable.prenatal.exists'])
+    assert_equal(
+      { Canql::BEGINS => ['Q2'] },
+      parser.meta_data['anomaly.probable.prenatal.icd_code']
+    )
+  end
+
+  def test_should_filter_by_multiple_probable_prenatal_codes_v1
+    parser = Canql::Parser.new('all cases with probable prenatal q2 and q3 anomalies')
+    assert parser.valid?
+    assert_equal({ Canql::EQUALS => true }, parser.meta_data['anomaly.probable.prenatal.exists'])
+    assert_equal(
+      { Canql::BEGINS => %w[Q2 Q3] },
+      parser.meta_data['anomaly.probable.prenatal.icd_code']
+    )
+  end
+
+  def test_should_filter_by_multiple_probable_prenatal_codes_v2
+    parser = Canql::Parser.new('all cases with probable prenatal q2, q3 anomalies')
+    assert parser.valid?
+    assert_equal({ Canql::EQUALS => true }, parser.meta_data['anomaly.probable.prenatal.exists'])
+    assert_equal(
+      { Canql::BEGINS => %w[Q2 Q3] },
+      parser.meta_data['anomaly.probable.prenatal.icd_code']
+    )
+  end
+
+  def test_should_filter_by_multiple_probable_prenatal_codes_v3
+    parser = Canql::Parser.new('all cases with probable prenatal q1, q2 and q3 anomalies')
+    assert parser.valid?
+    assert_equal({ Canql::EQUALS => true }, parser.meta_data['anomaly.probable.prenatal.exists'])
+    assert_equal(
+      { Canql::BEGINS => %w[Q1 Q2 Q3] },
+      parser.meta_data['anomaly.probable.prenatal.icd_code']
+    )
+  end
+
+  def test_should_filter_by_sigle_probable_postnatal_code
+    parser = Canql::Parser.new('all cases with probable postnatal q2 anomalies')
+    assert parser.valid?
+    assert_equal({ Canql::EQUALS => true }, parser.meta_data['anomaly.probable.postnatal.exists'])
+    assert_equal(
+      { Canql::BEGINS => ['Q2'] },
+      parser.meta_data['anomaly.probable.postnatal.icd_code']
+    )
+  end
+
+  def test_should_filter_by_multiple_probable_postnatal_codes_v1
+    parser = Canql::Parser.new('all cases with probable postnatal q2 and q3 anomalies')
+    assert parser.valid?
+    assert_equal({ Canql::EQUALS => true }, parser.meta_data['anomaly.probable.postnatal.exists'])
+    assert_equal(
+      { Canql::BEGINS => %w[Q2 Q3] },
+      parser.meta_data['anomaly.probable.postnatal.icd_code']
+    )
+  end
+
+  def test_should_filter_by_multiple_probable_postnatal_codes_v2
+    parser = Canql::Parser.new('all cases with probable postnatal q2, q3 anomalies')
+    assert parser.valid?
+    assert_equal({ Canql::EQUALS => true }, parser.meta_data['anomaly.probable.postnatal.exists'])
+    assert_equal(
+      { Canql::BEGINS => %w[Q2 Q3] },
+      parser.meta_data['anomaly.probable.postnatal.icd_code']
+    )
+  end
+
+  def test_should_filter_by_multiple_probable_postnatal_codes_v3
+    parser = Canql::Parser.new('all cases with probable postnatal q1, q2 and q3 anomalies')
+    assert parser.valid?
+    assert_equal({ Canql::EQUALS => true }, parser.meta_data['anomaly.probable.postnatal.exists'])
+    assert_equal(
+      { Canql::BEGINS => %w[Q1 Q2 Q3] },
+      parser.meta_data['anomaly.probable.postnatal.icd_code']
+    )
+  end
+
+  def test_should_filter_by_no_sigle_code
+    parser = Canql::Parser.new('all cases with no q2 anomalies')
+    assert parser.valid?
+    assert_equal({ Canql::EQUALS => false }, parser.meta_data['anomaly.exists'])
+    assert_equal({ Canql::BEGINS => ['Q2'] }, parser.meta_data['anomaly.icd_code'])
+  end
+
+  def test_should_filter_by_some_sigle_code
+    parser = Canql::Parser.new('all cases with some q2 anomalies')
+    assert parser.valid?
+    assert_equal({ Canql::EQUALS => true }, parser.meta_data['anomaly.exists'])
+    assert_equal({ Canql::BEGINS => ['Q2'] }, parser.meta_data['anomaly.icd_code'])
+  end
+
+  def test_should_filter_by_no_sigle_suspected_code
+    parser = Canql::Parser.new('all cases with no suspected q2 anomalies')
+    assert parser.valid?
+    assert_equal({ Canql::EQUALS => false }, parser.meta_data['anomaly.suspected.exists'])
+    assert_equal({ Canql::BEGINS => ['Q2'] }, parser.meta_data['anomaly.suspected.icd_code'])
+  end
+
+  def test_should_filter_by_some_sigle_suspected_code
+    parser = Canql::Parser.new('all cases with some suspected q2 anomalies')
+    assert parser.valid?
+    assert_equal({ Canql::EQUALS => true }, parser.meta_data['anomaly.suspected.exists'])
+    assert_equal({ Canql::BEGINS => ['Q2'] }, parser.meta_data['anomaly.suspected.icd_code'])
+  end
+
+  def test_should_filter_with_multiple_anomaly_types
+    parser = Canql::Parser.new('all cases with suspected prenatal q2 anomalies and '\
+                               'no confirmed postnatal q3 and q4 anomalies')
+    assert parser.valid?
+    assert_equal({ Canql::EQUALS => true }, parser.meta_data['anomaly.suspected.prenatal.exists'])
+    assert_equal(
+      { Canql::BEGINS => ['Q2'] },
+      parser.meta_data['anomaly.suspected.prenatal.icd_code']
+    )
+    assert_equal({ Canql::EQUALS => false }, parser.meta_data['anomaly.confirmed.postnatal.exists'])
+    assert_equal(
+      { Canql::BEGINS => %w[Q3 Q4] },
+      parser.meta_data['anomaly.confirmed.postnatal.icd_code']
+    )
+  end
+end


### PR DESCRIPTION
This change extends the 'anomalies' rule to allow the specification of the anomaly status (eg.  Suspected) and a list of partial or complete ICD 10 BPA codes.  For example 'all cases with suspect q20 and q3 anomalies'.