### PR TITLE
Add alternative result subject to 'cases'.  Can now use 'patients'.  …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [Unreleased]
-*no unreleased changes*
+* Added new branch of CANQL for querying all patient not just child patients (#29)
 
 ## 2.10.0 / 2019-05-29
 ### Added

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ end
 would output:
 
 ```json
-{"patient.sex":{"equals":"1"},"patient.registry":{"equals":"84"}}
+{"results.subject":{"equals":"case"},"patient.sex":{"equals":"1"},"patient.registry":{"equals":"84"}}
 ```
       and booking at hospital RGT01 and delivery at addenbrookes trust
 The parser is case insensitive. An example of an almost fully involved CANQL query is:

--- a/lib/canql/grammars/main.treetop
+++ b/lib/canql/grammars/main.treetop
@@ -13,8 +13,15 @@ grammar Canql
 
   # The root grammar
   rule query
-    #quantity:record_count? pre:preconditions* cases_keyword post:additional_conditions*
-    quantity:record_count? pre:preconditions* cases_keyword post:additional_conditions* with_clause?
+    case_query / patient_query
+  end
+
+  rule case_query
+    quantity:record_count? pre:case_preconditions* cases_keyword post:case_additional_conditions* case_with_clause?
+  end
+
+  rule patient_query
+    quantity:record_count? pre:patient_preconditions* patient_keyword post:patient_additional_conditions* patient_with_clause?
   end
 
   rule word_break
@@ -44,19 +51,35 @@ grammar Canql
   end
 
   rule cases_keyword
-     space subject:('cases' / 'babies') word_break
+     space subject:('cases' / 'babies') word_break <Nodes::SubjectNode>
   end
 
-  rule preconditions
+  rule patient_keyword
+    space subject:'patients' word_break <Nodes::SubjectNode>
+  end
+
+  rule case_preconditions
     registry / gender / outcome / primacy
   end
 
-  rule additional_conditions
+  rule patient_preconditions
+     gender / primacy
+  end
+
+  rule case_additional_conditions
     and_keyword? (expected / with_birth_date / with_death_date)
   end
 
-  rule with_clause
-    with_keyword post:with_conditions+ <Nodes::WithConditions>
+  rule patient_additional_conditions
+    and_keyword? (with_birth_date / with_death_date)
+  end
+
+  rule case_with_clause
+    with_keyword post:case_with_conditions+ <Nodes::WithConditions>
+  end
+
+  rule patient_with_clause
+    with_keyword post:patient_with_conditions+ <Nodes::WithConditions>
   end
 
   rule with_keyword
@@ -103,7 +126,11 @@ grammar Canql
     space 'at' word_break
   end
 
-  rule with_conditions
-     anomalies / genetic_tests / test_results / perinatal_hospital / patient_field_existance / mother_conditions / action_or_ebr
+  rule case_with_conditions
+     anomalies / genetic_tests / test_results / perinatal_hospital / case_field_existance / mother_conditions / action_or_ebr
+  end
+
+  rule patient_with_conditions
+     anomalies / genetic_tests / test_results / patient_field_existance / action_or_ebr
   end
 end

--- a/lib/canql/grammars/patient.treetop
+++ b/lib/canql/grammars/patient.treetop
@@ -20,6 +20,10 @@ module Canql
       expected_keyword fuzzy_date <Nodes::Patient::ExpectedDateRangeNode>
     end
 
+    rule case_field_existance
+      and_keyword? field_existance_modifier:existance_keyword patient_field_list:case_field_list  <Nodes::Patient::FieldExists>
+    end
+
     rule patient_field_existance
       and_keyword? field_existance_modifier:existance_keyword patient_field_list:patient_field_list  <Nodes::Patient::FieldExists>
     end
@@ -28,15 +32,25 @@ module Canql
       space 'field' 's'? word_break
     end
 
+    rule case_field_list
+      space case_field_names (comma case_field_names)*
+    end
+
     rule patient_field_list
       space patient_field_names (comma patient_field_names)*
     end
 
-    rule patient_field_names
+    rule case_field_names
       patient_field_name:(
         'date of birth' / 'dob' / 'nhs number' / 'postcode' / 'birth weight' /
         'place of delivery' / 'sex' / 'outcome' / 'edd' /
         'expected delivery date' / 'booking hospital' / 'screening status'
+      )
+    end
+
+    rule patient_field_names
+      patient_field_name:(
+        'date of birth' / 'dob' / 'nhs number' / 'postcode' / 'sex'
       )
     end
 

--- a/lib/canql/nodes/main.rb
+++ b/lib/canql/nodes/main.rb
@@ -14,6 +14,16 @@ end
 
 module Canql #:nodoc: all
   module Nodes
+    # Returns a filter detailing the require result type (cases or patients)
+    module SubjectNode
+      def meta_data_item
+        type_map = { cases: 'case', babies: 'case', patients: 'patient' }
+        raise 'Unknown result type' if type_map[subject.text_value.to_sym].nil?
+
+        { 'results.subject' => { Canql::EQUALS => type_map[subject.text_value.to_sym] } }
+      end
+    end
+
     # Provides meta data for with conditions that return
     # multiple instances of a condition type as an array
     module WithConditions

--- a/test/nodes/anomaly_test.rb
+++ b/test/nodes/anomaly_test.rb
@@ -12,6 +12,19 @@ class AnomalyTest < Minitest::Test
     assert parser.valid?
     assert_anomaly_count parser, 1
     assert_anomaly_values parser, 0, 'exists' => { Canql::EQUALS => true }
+    assert_equal({ Canql::EQUALS => 'case' }, parser.meta_data['results.subject'])
+  end
+
+  # As the anomaly clause is the same for patient & case
+  # only this test is specifically on 'patients'.  All other
+  # anomaly clauses can be assumed to be true for patients as
+  # well as cases
+  def test_should_filter_by_anomaly_on_patient_results
+    parser = Canql::Parser.new('all patients with anomalies')
+    assert parser.valid?
+    assert_anomaly_count parser, 1
+    assert_anomaly_values parser, 0, 'exists' => { Canql::EQUALS => true }
+    assert_equal({ Canql::EQUALS => 'patient' }, parser.meta_data['results.subject'])
   end
 
   def test_should_filter_by_prenatal_anomaly

--- a/test/nodes/case_age_test.rb
+++ b/test/nodes/case_age_test.rb
@@ -2,13 +2,14 @@
 
 require 'test_helper'
 
-# case anomaly tests
-class AgeTest < Minitest::Test
+# case age tests
+class CasaAgeTest < Minitest::Test
   def test_should_filter_by_case_birth_date_range
     parser = Canql::Parser.new('all cases born between 10/01/2000 and 10/10/2010')
     assert parser.valid?
     assert_equal({ Canql::LIMITS => ['2000-01-10', '2010-10-10'] },
                  parser.meta_data['patient.birthdate'])
+    assert_equal({ Canql::EQUALS => 'case' }, parser.meta_data['results.subject'])
   end
 
   def test_should_filter_by_case_exect_birth_date
@@ -16,6 +17,7 @@ class AgeTest < Minitest::Test
     assert parser.valid?
     assert_equal({ Canql::LIMITS => ['2000-01-10', '2000-01-10'] },
                  parser.meta_data['patient.birthdate'])
+    assert_equal({ Canql::EQUALS => 'case' }, parser.meta_data['results.subject'])
   end
 
   def test_should_filter_by_mothers_birth_date_range
@@ -23,6 +25,7 @@ class AgeTest < Minitest::Test
     assert parser.valid?
     assert_equal({ Canql::LIMITS => ['2000-01-10', '2010-10-10'] },
                  parser.meta_data['mother.birthdate'])
+    assert_equal({ Canql::EQUALS => 'case' }, parser.meta_data['results.subject'])
   end
 
   def test_should_filter_by_mothers_exect_birth_date
@@ -30,6 +33,7 @@ class AgeTest < Minitest::Test
     assert parser.valid?
     assert_equal({ Canql::LIMITS => ['2000-01-10', '2000-01-10'] },
                  parser.meta_data['mother.birthdate'])
+    assert_equal({ Canql::EQUALS => 'case' }, parser.meta_data['results.subject'])
   end
 
   def test_should_filter_by_case_death_date_range
@@ -37,6 +41,7 @@ class AgeTest < Minitest::Test
     assert parser.valid?
     assert_equal({ Canql::LIMITS => ['2000-01-10', '2010-10-10'] },
                  parser.meta_data['patient.deathdate'])
+    assert_equal({ Canql::EQUALS => 'case' }, parser.meta_data['results.subject'])
   end
 
   def test_should_filter_by_case_exect_death_date
@@ -44,6 +49,7 @@ class AgeTest < Minitest::Test
     assert parser.valid?
     assert_equal({ Canql::LIMITS => ['2000-01-10', '2000-01-10'] },
                  parser.meta_data['patient.deathdate'])
+    assert_equal({ Canql::EQUALS => 'case' }, parser.meta_data['results.subject'])
   end
 
   def test_should_filter_by_mothers_death_date_range
@@ -51,6 +57,7 @@ class AgeTest < Minitest::Test
     assert parser.valid?
     assert_equal({ Canql::LIMITS => ['2000-01-10', '2010-10-10'] },
                  parser.meta_data['mother.deathdate'])
+    assert_equal({ Canql::EQUALS => 'case' }, parser.meta_data['results.subject'])
   end
 
   def test_should_filter_by_mothers_exect_death_date
@@ -58,6 +65,7 @@ class AgeTest < Minitest::Test
     assert parser.valid?
     assert_equal({ Canql::LIMITS => ['2000-01-10', '2000-01-10'] },
                  parser.meta_data['mother.deathdate'])
+    assert_equal({ Canql::EQUALS => 'case' }, parser.meta_data['results.subject'])
   end
 
   def test_should_filter_by_case_combined_birth_and_death_date
@@ -69,6 +77,7 @@ class AgeTest < Minitest::Test
                  parser.meta_data['patient.birthdate'])
     assert_equal({ Canql::LIMITS => ['2015-01-01', '2015-01-01'] },
                  parser.meta_data['patient.deathdate'])
+    assert_equal({ Canql::EQUALS => 'case' }, parser.meta_data['results.subject'])
   end
 
   def test_should_filter_by_mother_combined_birth_and_death_date
@@ -80,6 +89,7 @@ class AgeTest < Minitest::Test
                  parser.meta_data['mother.birthdate'])
     assert_equal({ Canql::LIMITS => ['2015-01-01', '2015-01-01'] },
                  parser.meta_data['mother.deathdate'])
+    assert_equal({ Canql::EQUALS => 'case' }, parser.meta_data['results.subject'])
   end
 
   def test_should_filter_by_case_birth_date_quarter
@@ -88,5 +98,6 @@ class AgeTest < Minitest::Test
     assert_nil parser.failure_reason
     assert_equal({ Canql::LIMITS => ['2015-04-01', '2015-06-30'] },
                  parser.meta_data['patient.birthdate'])
+    assert_equal({ Canql::EQUALS => 'case' }, parser.meta_data['results.subject'])
   end
 end

--- a/test/nodes/case_test.rb
+++ b/test/nodes/case_test.rb
@@ -1,0 +1,286 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+# case host patient tests
+class CaseTest < Minitest::Test
+  def test_should_filter_by_male_gender
+    parser = Canql::Parser.new('all male cases')
+    assert parser.valid?
+    assert_equal({ Canql::EQUALS => '1' }, parser.meta_data['patient.sex'])
+    assert_equal({ Canql::EQUALS => 'case' }, parser.meta_data['results.subject'])
+  end
+
+  def test_should_filter_by_female_gender
+    parser = Canql::Parser.new('all female cases')
+    assert parser.valid?
+    assert_equal({ Canql::EQUALS => '2' }, parser.meta_data['patient.sex'])
+    assert_equal({ Canql::EQUALS => 'case' }, parser.meta_data['results.subject'])
+  end
+
+  def test_should_filter_by_stillbirth_outcome
+    parser = Canql::Parser.new('all stillborn cases')
+    assert parser.valid?
+    assert_equal({ Canql::EQUALS => 'stillborn' }, parser.meta_data['patient.outcome'])
+    assert_equal({ Canql::EQUALS => 'case' }, parser.meta_data['results.subject'])
+  end
+
+  def test_should_filter_by_livebirth_outcome
+    parser = Canql::Parser.new('all liveborn cases')
+    assert parser.valid?
+    assert_equal({ Canql::EQUALS => 'liveborn' }, parser.meta_data['patient.outcome'])
+    assert_equal({ Canql::EQUALS => 'case' }, parser.meta_data['results.subject'])
+  end
+
+  def test_should_filter_by_miscarriage_outcome
+    parser = Canql::Parser.new('all miscarried cases')
+    assert parser.valid?
+    assert_equal({ Canql::EQUALS => 'miscarried' }, parser.meta_data['patient.outcome'])
+    assert_equal({ Canql::EQUALS => 'case' }, parser.meta_data['results.subject'])
+  end
+
+  def test_should_filter_by_top_outcome
+    parser = Canql::Parser.new('all terminated cases')
+    assert parser.valid?
+    assert_equal({ Canql::EQUALS => 'terminated' }, parser.meta_data['patient.outcome'])
+    assert_equal({ Canql::EQUALS => 'case' }, parser.meta_data['results.subject'])
+  end
+
+  def test_should_filter_by_primary_patient
+    parser = Canql::Parser.new('all primary cases')
+    assert parser.valid?
+    assert_equal({ Canql::EQUALS => 'primary' }, parser.meta_data['patient.primacy'])
+    assert_equal({ Canql::EQUALS => 'case' }, parser.meta_data['results.subject'])
+  end
+
+  def test_should_filter_by_alias_patient
+    parser = Canql::Parser.new('all alias cases')
+    assert parser.valid?
+    assert_equal({ Canql::EQUALS => 'alias' }, parser.meta_data['patient.primacy'])
+    assert_equal({ Canql::EQUALS => 'case' }, parser.meta_data['results.subject'])
+  end
+
+  def test_should_filter_on_specific_edd
+    parser = Canql::Parser.new('all cases expected on 20/06/2015')
+    assert parser.valid?
+    assert_equal({ Canql::LIMITS => ['2015-06-20', '2015-06-20'] },
+                 parser.meta_data['patient.expecteddeliverydate'])
+    assert_equal({ Canql::EQUALS => 'case' }, parser.meta_data['results.subject'])
+  end
+
+  def test_should_filter_on_edd_range
+    parser = Canql::Parser.new('all cases expected between 20/06/2015 and 25/06/2015')
+    assert parser.valid?
+    assert_equal({ Canql::LIMITS => ['2015-06-20', '2015-06-25'] },
+                 parser.meta_data['patient.expecteddeliverydate'])
+    assert_equal({ Canql::EQUALS => 'case' }, parser.meta_data['results.subject'])
+  end
+
+  def test_should_filter_on_edd_word_range
+    parser = Canql::Parser.new('all cases expected between today and tomorrow')
+    assert parser.valid?
+    today = Date.today
+    tomorrow = today + 1
+    assert_equal(
+      { Canql::LIMITS => [today.strftime('%Y-%m-%d'), tomorrow.strftime('%Y-%m-%d')] },
+      parser.meta_data['patient.expecteddeliverydate']
+    )
+    assert_equal({ Canql::EQUALS => 'case' }, parser.meta_data['results.subject'])
+  end
+
+  def test_should_filter_by_missing_fields
+    parser = Canql::Parser.new('all cases with missing postcode, date of birth')
+    parser_v2 = Canql::Parser.new('all cases with missing postcode and date of birth')
+    assert parser.valid?
+    assert_array_includes parser.meta_data['patient.fields_missing'][Canql::EQUALS],
+                          %w[postcode birthdate]
+    assert_array_includes parser_v2.meta_data['patient.fields_missing'][Canql::EQUALS],
+                          %w[postcode birthdate]
+    assert_equal({ Canql::EQUALS => 'case' }, parser.meta_data['results.subject'])
+  end
+
+  def test_should_filter_by_missing_place_of_delivery
+    parser = Canql::Parser.new('all cases with missing place of delivery')
+    assert parser.valid?
+    assert_array_includes parser.meta_data['patient.fields_missing'][Canql::EQUALS],
+                          %w[placeofdelivery]
+    assert_equal({ Canql::EQUALS => 'case' }, parser.meta_data['results.subject'])
+  end
+
+  def test_should_filter_by_missing_screening_status
+    parser = Canql::Parser.new('all cases with missing screening status')
+    assert parser.valid?
+    assert_array_includes parser.meta_data['patient.fields_missing'][Canql::EQUALS],
+                          %w[screeningstatus]
+    assert_equal({ Canql::EQUALS => 'case' }, parser.meta_data['results.subject'])
+  end
+
+  def test_should_filter_by_populated_fields
+    parser = Canql::Parser.new('all cases with fields postcode, date of birth')
+    parser_v2 = Canql::Parser.new('all cases with tests and fields postcode and date of birth')
+    assert parser.valid?
+    assert_array_includes parser.meta_data['patient.fields_populated'][Canql::EQUALS],
+                          %w[postcode birthdate]
+    assert_array_includes parser_v2.meta_data['patient.fields_populated'][Canql::EQUALS],
+                          %w[postcode birthdate]
+    assert_equal({ Canql::EQUALS => 'case' }, parser.meta_data['results.subject'])
+  end
+
+  def test_should_filter_by_missing_mother_fields
+    parser = Canql::Parser.new('all cases with mother with missing postcode, date of birth')
+    parser_v2 = Canql::Parser.new('all cases with mother with missing postcode and date of birth')
+    assert parser.valid?
+    assert_array_includes parser.meta_data['mother.fields_missing'][Canql::EQUALS],
+                          %w[postcode birthdate]
+    assert_array_includes parser_v2.meta_data['mother.fields_missing'][Canql::EQUALS],
+                          %w[postcode birthdate]
+    assert_equal({ Canql::EQUALS => 'case' }, parser.meta_data['results.subject'])
+  end
+
+  def test_should_filter_by_missing_mother_fields_v2
+    parser = Canql::Parser.new('all cases with mother missing postcode, date of birth')
+    parser_v2 = Canql::Parser.new('all cases with mother missing postcode and date of birth')
+    assert parser.valid?
+    assert_array_includes parser.meta_data['mother.fields_missing'][Canql::EQUALS],
+                          %w[postcode birthdate]
+    assert_array_includes parser_v2.meta_data['mother.fields_missing'][Canql::EQUALS],
+                          %w[postcode birthdate]
+    assert_equal({ Canql::EQUALS => 'case' }, parser.meta_data['results.subject'])
+  end
+
+  def test_should_filter_by_populated_mother_fields
+    parser = Canql::Parser.new('all cases with mother with fields postcode, date of birth')
+    parser_v2 = Canql::Parser.new('all cases with mother with fields postcode and date of birth')
+    assert parser.valid?
+    assert_array_includes parser.meta_data['mother.fields_populated'][Canql::EQUALS],
+                          %w[postcode birthdate]
+    assert_array_includes parser_v2.meta_data['mother.fields_populated'][Canql::EQUALS],
+                          %w[postcode birthdate]
+    assert_equal({ Canql::EQUALS => 'case' }, parser.meta_data['results.subject'])
+  end
+
+  def test_dob_alias_valid
+    query1 = 'all babies with missing date of birth'
+    parser = Canql::Parser.new(query1)
+    message = "That's a reference test for 'dob' alias, if this fails,\
+               something is wrong!!!"
+    assert(parser.valid?, message)
+
+    query1 = 'all babies with missing dob'
+    parser = Canql::Parser.new(query1)
+    correct = base_meta_data.merge(
+      'patient.fields_missing' => { 'equals' => ['birthdate'] }
+    )
+    message = '\'dob\' should be a valid alias for \'date of birth\'!'
+    assert(parser.valid?, message)
+    assert_equal(correct, parser.meta_data, message)
+    assert_equal({ Canql::EQUALS => 'case' }, parser.meta_data['results.subject'])
+  end
+
+  def test_dob_alias_query
+    query1 = 'all babies with missing postcode, date of birth'
+    query2 = 'all babies with missing postcode, dob'
+    parser1 = Canql::Parser.new(query1)
+    parser2 = Canql::Parser.new(query2)
+    message = '\'dob\' doesn\'t work as an alias of \'date of birth\'!'
+    assert parser1.valid?
+    assert parser2.valid?
+    assert_equal(parser1.meta_data, parser2.meta_data, message)
+
+    query1 = "first 27 male liveborn thames cases \
+      expected between 20/06/2015 and 25/06/2015 \
+      and born on 22/06/2015 and that died on 01/12/2015 \
+      with prenatal anomalies \
+      and postnatal tests and missing postcode and date of birth \
+      and qa action and unprocessed paediatric records \
+      and mother born between 01/10/1990 and 10/01/1999 \
+      and who died on 01/01/2016 \
+      with fields postcode and nhs number"
+    query2 = "first 27 male liveborn thames cases \
+      expected between 20/06/2015 and 25/06/2015 \
+      and born on 22/06/2015 and that died on 01/12/2015 \
+      with prenatal anomalies \
+      and postnatal tests and missing postcode and dob \
+      and qa action and unprocessed paediatric records \
+      and mother born between 01/10/1990 and 10/01/1999 \
+      and who died on 01/01/2016 \
+      with fields postcode and nhs number"
+    parser1 = Canql::Parser.new(query1)
+    parser2 = Canql::Parser.new(query2)
+    message1 = 'parser1 is not valid!'
+    message2 = 'parser2 is not valid!'
+    message3 = "'dob' doesn't work as an alias of 'date of birth'\
+      in a complicated query!"
+    assert parser1.valid?, message1
+    assert parser2.valid?, message2
+    assert_equal(parser1.meta_data, parser2.meta_data, message3)
+  end
+
+  def test_should_not_filter_for_field_existance_on_nonmother_field
+    parser = Canql::Parser.new('all cases with mother with populated outcome')
+    refute parser.valid?
+  end
+
+  def test_should_filter_on_missing_edd
+    parser = Canql::Parser.new('all cases with missing edd')
+    assert parser.valid?
+    assert_array_includes parser.meta_data['patient.fields_missing'][Canql::EQUALS],
+                          %w[expecteddeliverydate]
+
+    parser = Canql::Parser.new('all cases with missing expected delivery date')
+    assert parser.valid?
+    assert_array_includes parser.meta_data['patient.fields_missing'][Canql::EQUALS],
+                          %w[expecteddeliverydate]
+    assert_equal({ Canql::EQUALS => 'case' }, parser.meta_data['results.subject'])
+  end
+
+  def test_should_filter_on_missing_booking_hospital
+    parser = Canql::Parser.new('all cases with missing booking hospital')
+    assert parser.valid?
+    assert_array_includes parser.meta_data['patient.fields_missing'][Canql::EQUALS],
+                          %w[booking_hospital]
+    assert_equal({ Canql::EQUALS => 'case' }, parser.meta_data['results.subject'])
+  end
+
+  def test_should_filter_on_populated_edd
+    parser = Canql::Parser.new('all cases with populated edd')
+    assert parser.valid?
+    assert_array_includes parser.meta_data['patient.fields_populated'][Canql::EQUALS],
+                          %w[expecteddeliverydate]
+
+    parser = Canql::Parser.new('all cases with populated expected delivery date')
+    assert parser.valid?
+    assert_array_includes parser.meta_data['patient.fields_populated'][Canql::EQUALS],
+                          %w[expecteddeliverydate]
+    assert_equal({ Canql::EQUALS => 'case' }, parser.meta_data['results.subject'])
+  end
+
+  def test_should_filter_on_populated_booking_hospital
+    parser = Canql::Parser.new('all cases with populated booking hospital')
+    assert parser.valid?
+    assert_array_includes parser.meta_data['patient.fields_populated'][Canql::EQUALS],
+                          %w[booking_hospital]
+    assert_equal({ Canql::EQUALS => 'case' }, parser.meta_data['results.subject'])
+  end
+
+  def test_should_not_filter_on_missing_edd_on_mother
+    parser = Canql::Parser.new('all cases with mother with missing edd')
+    refute parser.valid?
+
+    parser = Canql::Parser.new('all cases with mother with missing expected delivery date')
+    refute parser.valid?
+  end
+
+  def test_should_not_filter_on_missing_booking_hospital_on_mother
+    parser = Canql::Parser.new('all cases with mother with missing booking hospital')
+    refute parser.valid?
+  end
+
+  def test_should_not_filter_on_populated_edd_on_mother
+    parser = Canql::Parser.new('all cases with mother with populated edd')
+    refute parser.valid?
+
+    parser = Canql::Parser.new('all cases with mother with populated expected delivery date')
+    refute parser.valid?
+  end
+end

--- a/test/nodes/e_base_records_test.rb
+++ b/test/nodes/e_base_records_test.rb
@@ -8,6 +8,14 @@ class EBaseRecordsTest < Minitest::Test
     parser = Canql::Parser.new('all cases with qa action')
     assert parser.valid?
     assert_equal({ Canql::EQUALS => 'QA' }, parser.meta_data['action.actioninitiated'])
+    assert_equal({ Canql::EQUALS => 'case' }, parser.meta_data['results.subject'])
+  end
+
+  def test_should_filter_by_qa_action_on_patients
+    parser = Canql::Parser.new('all patients with qa action')
+    assert parser.valid?
+    assert_equal({ Canql::EQUALS => 'QA' }, parser.meta_data['action.actioninitiated'])
+    assert_equal({ Canql::EQUALS => 'patient' }, parser.meta_data['results.subject'])
   end
 
   def test_should_filter_by_scr_check_action
@@ -68,6 +76,14 @@ class EBaseRecordsTest < Minitest::Test
     parser = Canql::Parser.new('all cases with unprocessed records')
     assert parser.valid?
     assert_equal({ Canql::ALL => true }, parser.meta_data['unprocessed_records.sources'])
+    assert_equal({ Canql::EQUALS => 'case' }, parser.meta_data['results.subject'])
+  end
+
+  def test_should_filter_by_unprocessed_records_on_patients
+    parser = Canql::Parser.new('all patients with unprocessed records')
+    assert parser.valid?
+    assert_equal({ Canql::ALL => true }, parser.meta_data['unprocessed_records.sources'])
+    assert_equal({ Canql::EQUALS => 'patient' }, parser.meta_data['results.subject'])
   end
 
   def test_should_filter_by_unprocessed_paediatric_records

--- a/test/nodes/genetic_tests_test.rb
+++ b/test/nodes/genetic_tests_test.rb
@@ -9,6 +9,19 @@ class GeneticTest < Minitest::Test
     assert parser.valid?
     assert_genetic_test_count parser, 1
     assert_genetic_test_values parser, 0, 'exists' => { Canql::EQUALS => true }
+    assert_equal({ Canql::EQUALS => 'case' }, parser.meta_data['results.subject'])
+  end
+
+  # As the genetic test clause is the same for patient & case
+  # only this test is specifically on 'patients'.  All other
+  # anomaly clauses can be assumed to be true for patients as
+  # well as cases
+  def test_should_filter_by_genetic_test_on_patient_results
+    parser = Canql::Parser.new('all patients with genetic tests')
+    assert parser.valid?
+    assert_genetic_test_count parser, 1
+    assert_genetic_test_values parser, 0, 'exists' => { Canql::EQUALS => true }
+    assert_equal({ Canql::EQUALS => 'patient' }, parser.meta_data['results.subject'])
   end
 
   def test_should_filter_by_no_genetic_test

--- a/test/nodes/main_case_test.rb
+++ b/test/nodes/main_case_test.rb
@@ -3,12 +3,13 @@
 require 'test_helper'
 
 # main entry point tests
-class MainTest < Minitest::Test
+class MainCaseTest < Minitest::Test
   def test_should_not_filter_all_tumours
     parser = Canql::Parser.new('all cases')
     assert parser.valid?
     assert_instance_of Hash, parser.meta_data
-    assert parser.meta_data.empty?
+    assert_equal 1, parser.meta_data.count
+    assert_equal base_meta_data, parser.meta_data
     assert_nil parser.failure_reason
   end
 

--- a/test/nodes/main_patient_test.rb
+++ b/test/nodes/main_patient_test.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+# main entry point tests (For patient results)
+class MainPatientTest < Minitest::Test
+  def test_should_not_filter_all_tumours
+    parser = Canql::Parser.new('all patients')
+    assert parser.valid?
+    assert_instance_of Hash, parser.meta_data
+    assert_equal 1, parser.meta_data.count
+    assert_equal base_meta_data(:patient), parser.meta_data
+    assert_nil parser.failure_reason
+  end
+
+  def test_should_filter_by_record_count
+    parser = Canql::Parser.new('first 27 patients')
+    assert parser.valid?
+    assert_equal({ Canql::EQUALS => 27 }, parser.meta_data['limit'])
+  end
+
+  def test_fails_for_unknown_result_type
+    parser = Canql::Parser.new('all cabbages')
+    refute parser.valid?
+  end
+end

--- a/test/nodes/patient_age_test.rb
+++ b/test/nodes/patient_age_test.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+# Patient age tests
+class PatientAgeTest < Minitest::Test
+  def test_should_filter_by_case_birth_date_range
+    parser = Canql::Parser.new('all patients born between 10/01/2000 and 10/10/2010')
+    assert parser.valid?
+    assert_equal({ Canql::LIMITS => ['2000-01-10', '2010-10-10'] },
+                 parser.meta_data['patient.birthdate'])
+    assert_equal({ Canql::EQUALS => 'patient' }, parser.meta_data['results.subject'])
+  end
+
+  def test_should_filter_by_case_exect_birth_date
+    parser = Canql::Parser.new('all patients born on 10/01/2000')
+    assert parser.valid?
+    assert_equal({ Canql::LIMITS => ['2000-01-10', '2000-01-10'] },
+                 parser.meta_data['patient.birthdate'])
+    assert_equal({ Canql::EQUALS => 'patient' }, parser.meta_data['results.subject'])
+  end
+
+  def test_should_filter_by_case_death_date_range
+    parser = Canql::Parser.new('all patients who died between 10/01/2000 and 10/10/2010')
+    assert parser.valid?
+    assert_equal({ Canql::LIMITS => ['2000-01-10', '2010-10-10'] },
+                 parser.meta_data['patient.deathdate'])
+    assert_equal({ Canql::EQUALS => 'patient' }, parser.meta_data['results.subject'])
+  end
+
+  def test_should_filter_by_case_exect_death_date
+    parser = Canql::Parser.new('all patients that died on 10/01/2000')
+    assert parser.valid?
+    assert_equal({ Canql::LIMITS => ['2000-01-10', '2000-01-10'] },
+                 parser.meta_data['patient.deathdate'])
+    assert_equal({ Canql::EQUALS => 'patient' }, parser.meta_data['results.subject'])
+  end
+
+  def test_should_filter_by_case_combined_birth_and_death_date
+    parser = Canql::Parser.new(
+      'all patients born between 10/01/2000 and 10/10/2010 and that died on 01/01/2015'
+    )
+    assert parser.valid?
+    assert_equal({ Canql::LIMITS => ['2000-01-10', '2010-10-10'] },
+                 parser.meta_data['patient.birthdate'])
+    assert_equal({ Canql::LIMITS => ['2015-01-01', '2015-01-01'] },
+                 parser.meta_data['patient.deathdate'])
+    assert_equal({ Canql::EQUALS => 'patient' }, parser.meta_data['results.subject'])
+  end
+
+  def test_should_filter_by_case_birth_date_quarter
+    parser = Canql::Parser.new('all patients born in Q1 2015')
+    assert parser.valid?, parser.failure_reason
+    assert_nil parser.failure_reason
+    assert_equal({ Canql::LIMITS => ['2015-04-01', '2015-06-30'] },
+                 parser.meta_data['patient.birthdate'])
+    assert_equal({ Canql::EQUALS => 'patient' }, parser.meta_data['results.subject'])
+  end
+end

--- a/test/nodes/patient_test.rb
+++ b/test/nodes/patient_test.rb
@@ -2,163 +2,119 @@
 
 require 'test_helper'
 
-# case host patient tests
-class PatientTest < Minitest::Test
-  def test_should_filter_by_male_gender
-    parser = Canql::Parser.new('all male cases')
+# Patient host patient tests
+class Patientest < Minitest::Test
+  def test_should_filter_by_male_gender_patients
+    parser = Canql::Parser.new('all male patients')
     assert parser.valid?
     assert_equal({ Canql::EQUALS => '1' }, parser.meta_data['patient.sex'])
+    assert_equal({ Canql::EQUALS => 'patient' }, parser.meta_data['results.subject'])
   end
 
-  def test_should_filter_by_female_gender
-    parser = Canql::Parser.new('all female cases')
+  def test_should_filter_by_female_gender_patients
+    parser = Canql::Parser.new('all female patients')
     assert parser.valid?
     assert_equal({ Canql::EQUALS => '2' }, parser.meta_data['patient.sex'])
+    assert_equal({ Canql::EQUALS => 'patient' }, parser.meta_data['results.subject'])
   end
 
-  def test_should_filter_by_stillbirth_outcome
-    parser = Canql::Parser.new('all stillborn cases')
-    assert parser.valid?
-    assert_equal({ Canql::EQUALS => 'stillborn' }, parser.meta_data['patient.outcome'])
+  def test_should_not_filter_by_stillbirth_outcome
+    parser = Canql::Parser.new('all stillborn patients')
+    refute parser.valid?
   end
 
-  def test_should_filter_by_livebirth_outcome
-    parser = Canql::Parser.new('all liveborn cases')
-    assert parser.valid?
-    assert_equal({ Canql::EQUALS => 'liveborn' }, parser.meta_data['patient.outcome'])
+  def test_not_should_filter_by_livebirth_outcome
+    parser = Canql::Parser.new('all liveborn patients')
+    refute parser.valid?
   end
 
-  def test_should_filter_by_miscarriage_outcome
-    parser = Canql::Parser.new('all miscarried cases')
-    assert parser.valid?
-    assert_equal({ Canql::EQUALS => 'miscarried' }, parser.meta_data['patient.outcome'])
+  def test_not_should_filter_by_miscarriage_outcome
+    parser = Canql::Parser.new('all miscarried patients')
+    refute parser.valid?
   end
 
-  def test_should_filter_by_top_outcome
-    parser = Canql::Parser.new('all terminated cases')
-    assert parser.valid?
-    assert_equal({ Canql::EQUALS => 'terminated' }, parser.meta_data['patient.outcome'])
+  def test_not_should_filter_by_top_outcome
+    parser = Canql::Parser.new('all terminated patients')
+    refute parser.valid?
   end
 
-  def test_should_filter_by_primary_patient
-    parser = Canql::Parser.new('all primary cases')
+  def test_should_filter_by_primary_patient_patients
+    parser = Canql::Parser.new('all primary patients')
     assert parser.valid?
     assert_equal({ Canql::EQUALS => 'primary' }, parser.meta_data['patient.primacy'])
+    assert_equal({ Canql::EQUALS => 'patient' }, parser.meta_data['results.subject'])
   end
 
   def test_should_filter_by_alias_patient
-    parser = Canql::Parser.new('all alias cases')
+    parser = Canql::Parser.new('all alias patients')
     assert parser.valid?
     assert_equal({ Canql::EQUALS => 'alias' }, parser.meta_data['patient.primacy'])
+    assert_equal({ Canql::EQUALS => 'patient' }, parser.meta_data['results.subject'])
   end
 
-  def test_should_filter_on_specific_edd
-    parser = Canql::Parser.new('all cases expected on 20/06/2015')
-    assert parser.valid?
-    assert_equal({ Canql::LIMITS => ['2015-06-20', '2015-06-20'] },
-                 parser.meta_data['patient.expecteddeliverydate'])
+  def test_should_not_filter_on_specific_edd
+    parser = Canql::Parser.new('all patient expected on 20/06/2015')
+    refute parser.valid?
   end
 
-  def test_should_filter_on_edd_range
-    parser = Canql::Parser.new('all cases expected between 20/06/2015 and 25/06/2015')
-    assert parser.valid?
-    assert_equal({ Canql::LIMITS => ['2015-06-20', '2015-06-25'] },
-                 parser.meta_data['patient.expecteddeliverydate'])
-  end
-
-  def test_should_filter_on_edd_word_range
-    parser = Canql::Parser.new('all cases expected between today and tomorrow')
-    assert parser.valid?
-    today = Date.today
-    tomorrow = today + 1
-    assert_equal(
-      { Canql::LIMITS => [today.strftime('%Y-%m-%d'), tomorrow.strftime('%Y-%m-%d')] },
-      parser.meta_data['patient.expecteddeliverydate']
-    )
+  def test_should_not_filter_on_edd_range
+    parser = Canql::Parser.new('all patient expected between 20/06/2015 and 25/06/2015')
+    refute parser.valid?
   end
 
   def test_should_filter_by_missing_fields
-    parser = Canql::Parser.new('all cases with missing postcode, date of birth')
-    parser_v2 = Canql::Parser.new('all cases with missing postcode and date of birth')
+    parser = Canql::Parser.new('all patients with missing postcode, date of birth')
+    parser_v2 = Canql::Parser.new('all patients with missing postcode and date of birth')
     assert parser.valid?
     assert_array_includes parser.meta_data['patient.fields_missing'][Canql::EQUALS],
                           %w[postcode birthdate]
     assert_array_includes parser_v2.meta_data['patient.fields_missing'][Canql::EQUALS],
                           %w[postcode birthdate]
+    assert_equal({ Canql::EQUALS => 'patient' }, parser.meta_data['results.subject'])
   end
 
-  def test_should_filter_by_missing_place_of_delivery
-    parser = Canql::Parser.new('all cases with missing place of delivery')
-    assert parser.valid?
-    assert_array_includes parser.meta_data['patient.fields_missing'][Canql::EQUALS],
-                          %w[placeofdelivery]
+  def test_should_not_filter_by_missing_place_of_delivery
+    parser = Canql::Parser.new('all patients with missing place of delivery')
+    refute parser.valid?
   end
 
-  def test_should_filter_by_missing_screening_status
-    parser = Canql::Parser.new('all cases with missing screening status')
-    assert parser.valid?
-    assert_array_includes parser.meta_data['patient.fields_missing'][Canql::EQUALS],
-                          %w[screeningstatus]
+  def test_should_not_filter_by_missing_screening_status
+    parser = Canql::Parser.new('all patients with missing screening status')
+    refute parser.valid?
   end
 
   def test_should_filter_by_populated_fields
-    parser = Canql::Parser.new('all cases with fields postcode, date of birth')
-    parser_v2 = Canql::Parser.new('all cases with tests and fields postcode and date of birth')
+    parser = Canql::Parser.new('all patients with fields postcode, date of birth')
+    parser_v2 = Canql::Parser.new('all patients with tests and fields postcode and date of birth')
     assert parser.valid?
     assert_array_includes parser.meta_data['patient.fields_populated'][Canql::EQUALS],
                           %w[postcode birthdate]
     assert_array_includes parser_v2.meta_data['patient.fields_populated'][Canql::EQUALS],
                           %w[postcode birthdate]
-  end
-
-  def test_should_filter_by_missing_mother_fields
-    parser = Canql::Parser.new('all cases with mother with missing postcode, date of birth')
-    parser_v2 = Canql::Parser.new('all cases with mother with missing postcode and date of birth')
-    assert parser.valid?
-    assert_array_includes parser.meta_data['mother.fields_missing'][Canql::EQUALS],
-                          %w[postcode birthdate]
-    assert_array_includes parser_v2.meta_data['mother.fields_missing'][Canql::EQUALS],
-                          %w[postcode birthdate]
-  end
-
-  def test_should_filter_by_missing_mother_fields_v2
-    parser = Canql::Parser.new('all cases with mother missing postcode, date of birth')
-    parser_v2 = Canql::Parser.new('all cases with mother missing postcode and date of birth')
-    assert parser.valid?
-    assert_array_includes parser.meta_data['mother.fields_missing'][Canql::EQUALS],
-                          %w[postcode birthdate]
-    assert_array_includes parser_v2.meta_data['mother.fields_missing'][Canql::EQUALS],
-                          %w[postcode birthdate]
-  end
-
-  def test_should_filter_by_populated_mother_fields
-    parser = Canql::Parser.new('all cases with mother with fields postcode, date of birth')
-    parser_v2 = Canql::Parser.new('all cases with mother with fields postcode and date of birth')
-    assert parser.valid?
-    assert_array_includes parser.meta_data['mother.fields_populated'][Canql::EQUALS],
-                          %w[postcode birthdate]
-    assert_array_includes parser_v2.meta_data['mother.fields_populated'][Canql::EQUALS],
-                          %w[postcode birthdate]
+    assert_equal({ Canql::EQUALS => 'patient' }, parser.meta_data['results.subject'])
   end
 
   def test_dob_alias_valid
-    query1 = 'all babies with missing date of birth'
+    query1 = 'all patients with missing date of birth'
     parser = Canql::Parser.new(query1)
     message = "That's a reference test for 'dob' alias, if this fails,\
                something is wrong!!!"
     assert(parser.valid?, message)
 
-    query1 = 'all babies with missing dob'
+    query1 = 'all patients with missing dob'
     parser = Canql::Parser.new(query1)
-    correct = { 'patient.fields_missing' => { 'equals' => ['birthdate'] } }
+    correct = base_meta_data(:patient).merge(
+      'patient.fields_missing' => { 'equals' => ['birthdate'] }
+    )
     message = '\'dob\' should be a valid alias for \'date of birth\'!'
     assert(parser.valid?, message)
     assert_equal(correct, parser.meta_data, message)
+    assert_equal({ Canql::EQUALS => 'patient' }, parser.meta_data['results.subject'])
   end
 
   def test_dob_alias_query
-    query1 = 'all babies with missing postcode, date of birth'
-    query2 = 'all babies with missing postcode, dob'
+    query1 = 'all patients with missing postcode, date of birth'
+    query2 = 'all patients with missing postcode, dob'
     parser1 = Canql::Parser.new(query1)
     parser2 = Canql::Parser.new(query2)
     message = '\'dob\' doesn\'t work as an alias of \'date of birth\'!'
@@ -166,24 +122,16 @@ class PatientTest < Minitest::Test
     assert parser2.valid?
     assert_equal(parser1.meta_data, parser2.meta_data, message)
 
-    query1 = "first 27 male liveborn thames cases \
-      expected between 20/06/2015 and 25/06/2015 \
-      and born on 22/06/2015 and that died on 01/12/2015 \
+    query1 = "first 27 male patients \
+      born on 22/06/2015 and that died on 01/12/2015 \
       with prenatal anomalies \
       and postnatal tests and missing postcode and date of birth \
-      and qa action and unprocessed paediatric records \
-      and mother born between 01/10/1990 and 10/01/1999 \
-      and who died on 01/01/2016 \
-      with fields postcode and nhs number"
-    query2 = "first 27 male liveborn thames cases \
-      expected between 20/06/2015 and 25/06/2015 \
+      and qa action and unprocessed paediatric records"
+    query2 = "first 27 male patients \
       and born on 22/06/2015 and that died on 01/12/2015 \
       with prenatal anomalies \
       and postnatal tests and missing postcode and dob \
-      and qa action and unprocessed paediatric records \
-      and mother born between 01/10/1990 and 10/01/1999 \
-      and who died on 01/01/2016 \
-      with fields postcode and nhs number"
+      and qa action and unprocessed paediatric records"
     parser1 = Canql::Parser.new(query1)
     parser2 = Canql::Parser.new(query2)
     message1 = 'parser1 is not valid!'
@@ -195,76 +143,34 @@ class PatientTest < Minitest::Test
     assert_equal(parser1.meta_data, parser2.meta_data, message3)
   end
 
-  def test_should_be_no_fields_for_field_existance_on_nonmother_field
-    parser = Canql::Parser.new('all cases with mother with populated outcome')
-    assert parser.valid?
-    assert_equal(
-      { Canql::EQUALS => [] },
-      parser.meta_data['mother.fields_populated']
-    )
+  def test_should_not_filter_on_missing_edd
+    parser = Canql::Parser.new('all patients with missing edd')
+    refute parser.valid?
+
+    parser = Canql::Parser.new('all patients with missing expected delivery date')
+    refute parser.valid?
   end
 
-  def test_should_filter_on_missing_edd
-    parser = Canql::Parser.new('all cases with missing edd')
-    assert parser.valid?
-    assert_array_includes parser.meta_data['patient.fields_missing'][Canql::EQUALS],
-                          %w[expecteddeliverydate]
-
-    parser = Canql::Parser.new('all cases with missing expected delivery date')
-    assert parser.valid?
-    assert_array_includes parser.meta_data['patient.fields_missing'][Canql::EQUALS],
-                          %w[expecteddeliverydate]
+  def test_should_not_filter_on_missing_booking_hospital
+    parser = Canql::Parser.new('all patients with missing booking hospital')
+    refute parser.valid?
   end
 
-  def test_should_filter_on_missing_booking_hospital
-    parser = Canql::Parser.new('all cases with missing booking hospital')
-    assert parser.valid?
-    assert_array_includes parser.meta_data['patient.fields_missing'][Canql::EQUALS],
-                          %w[booking_hospital]
+  def test_should_not_filter_on_populated_edd
+    parser = Canql::Parser.new('all patients with populated edd')
+    refute parser.valid?
+
+    parser = Canql::Parser.new('all patients with populated expected delivery date')
+    refute parser.valid?
   end
 
-  def test_should_filter_on_populated_edd
-    parser = Canql::Parser.new('all cases with populated edd')
-    assert parser.valid?
-    assert_array_includes parser.meta_data['patient.fields_populated'][Canql::EQUALS],
-                          %w[expecteddeliverydate]
-
-    parser = Canql::Parser.new('all cases with populated expected delivery date')
-    assert parser.valid?
-    assert_array_includes parser.meta_data['patient.fields_populated'][Canql::EQUALS],
-                          %w[expecteddeliverydate]
+  def test_should_not_filter_on_populated_booking_hospital
+    parser = Canql::Parser.new('all patients with populated booking hospital')
+    refute parser.valid?
   end
 
-  def test_should_filter_on_populated_booking_hospital
-    parser = Canql::Parser.new('all cases with populated booking hospital')
-    assert parser.valid?
-    assert_array_includes parser.meta_data['patient.fields_populated'][Canql::EQUALS],
-                          %w[booking_hospital]
-  end
-
-  def test_should_not_filter_on_missing_edd_on_mother
-    parser = Canql::Parser.new('all cases with mother with missing edd')
-    assert parser.valid?
-    assert parser.meta_data['mother.fields_missing'][Canql::EQUALS].empty?
-
-    parser = Canql::Parser.new('all cases with mother with missing expected delivery date')
-    assert parser.valid?
-    assert parser.meta_data['mother.fields_missing'][Canql::EQUALS].empty?
-  end
-
-  def test_should_not_filter_on_missing_booking_hospital_on_mother
-    parser = Canql::Parser.new('all cases with mother with missing booking hospital')
-    assert parser.valid?
-    assert parser.meta_data['mother.fields_missing'][Canql::EQUALS].empty?
-  end
-
-  def test_should_not_filter_on_populated_edd_on_mother
-    parser = Canql::Parser.new('all cases with mother with populated edd')
-    assert parser.valid?
-    assert parser.meta_data['mother.fields_populated'][Canql::EQUALS].empty?
-
-    parser = Canql::Parser.new('all cases with mother with populated expected delivery date')
-    assert parser.valid?
-    assert parser.meta_data['mother.fields_populated'][Canql::EQUALS].empty?
+  def test_should_not_filter_on__mother
+    parser = Canql::Parser.new('all patients with mother with populated dob')
+    refute parser.valid?
   end
 end

--- a/test/nodes/perinatal_hospital_test.rb
+++ b/test/nodes/perinatal_hospital_test.rb
@@ -8,6 +8,12 @@ class PerinatalHospitalTest < Minitest::Test
     parser = Canql::Parser.new('all cases with booking at hospital RGT01')
     assert parser.valid?
     assert_equal({ Canql::EQUALS => 'RGT01' }, parser.meta_data['booking.providercode'])
+    assert_equal({ Canql::EQUALS => 'case' }, parser.meta_data['results.subject'])
+  end
+
+  def test_should_not_filter_by_booking_hosital_code_on_patients
+    parser = Canql::Parser.new('all patients with booking at hospital RGT01')
+    refute parser.valid?
   end
 
   def test_should_filter_by_booking_trust_code

--- a/test/nodes/registry_test.rb
+++ b/test/nodes/registry_test.rb
@@ -8,6 +8,12 @@ class RegistryTest < Minitest::Test
     parser = Canql::Parser.new('all 68 cases')
     assert parser.valid?
     assert_equal({ Canql::EQUALS => '68' }, parser.meta_data['patient.registry'])
+    assert_equal({ Canql::EQUALS => 'case' }, parser.meta_data['results.subject'])
+  end
+
+  def test_should_not_filter_by_registry_code_on_patient
+    parser = Canql::Parser.new('all 68 patients')
+    refute parser.valid?
   end
 
   def test_should_filter_by_thames_abbreviation

--- a/test/nodes/test_results_test.rb
+++ b/test/nodes/test_results_test.rb
@@ -9,6 +9,19 @@ class TestResultsTest < Minitest::Test
     assert parser.valid?
     assert_test_result_count parser, 1
     assert_test_result_values parser, 0, 'exists' => { Canql::EQUALS => true }
+    assert_equal({ Canql::EQUALS => 'case' }, parser.meta_data['results.subject'])
+  end
+
+  # As the test clause is the same for patient & case
+  # only this test is specifically on 'patients'.  All other
+  # anomaly clauses can be assumed to be true for patients as
+  # well as cases
+  def test_should_filter_by_test_result_on_patient_results
+    parser = Canql::Parser.new('all patients with tests')
+    assert parser.valid?
+    assert_test_result_count parser, 1
+    assert_test_result_values parser, 0, 'exists' => { Canql::EQUALS => true }
+    assert_equal({ Canql::EQUALS => 'patient' }, parser.meta_data['results.subject'])
   end
 
   def test_should_filter_by_prenatal_test_result

--- a/test/parser_test.rb
+++ b/test/parser_test.rb
@@ -33,13 +33,15 @@ class ParserTest < Minitest::Test
   def test_should_cope_with_a_mixed_case_query
     parser = Canql::Parser.new('All Cases')
     assert parser.valid?
-    assert parser.meta_data.empty?
+    assert_equal 1, parser.meta_data.count
+    assert_equal base_meta_data, parser.meta_data
     assert_nil parser.failure_reason
   end
 
   # advanced tests
 
   def test_should_combine_filters
+    # TODO: Add unprocessed record clauses
     parser = Canql::Parser.new("first 27 male liveborn thames primary cases \
       expected between 20/06/2015 and 25/06/2015 \
       and born on 22/06/2015 and that died on 01/12/2015 \
@@ -52,7 +54,7 @@ class ParserTest < Minitest::Test
       and who died on 01/01/2016 \
       with fields postcode and nhs number")
     assert parser.valid?
-    assert_equal 18, parser.meta_data.count
+    assert_equal 19, parser.meta_data.count
     individual_queries = [
       'first 27 cases',
       'first 27 babies',

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -65,3 +65,7 @@ def assert_dir_block_has_expected_keys(dir_block, expected = {})
   assert expected.keys.reject { |key| dir_block.include?(key) }.none?,
          'Expected key not present in DIR block'
 end
+
+def base_meta_data(result_type = :case)
+  { 'results.subject' => { Canql::EQUALS => result_type.to_s } }
+end


### PR DESCRIPTION
…All qeries now return a 'result.subject' filter to reflect this (Resolves #29)
Please merge.  This is a breaking change so bump to version 3.0.0.  Cheers