### PR TITLE
Added POSTNATAL and ANTENATAL batch types (NIT-2930)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [Unreleased]
 ### Fixed
 * Support Ruby 4.0, Rails 8.1. Drop support for Ruby 3.2
+### Added
+* Added support for antenatal and postnatal batch types
 
 ## 6.1.0 / 2026-03-24
 ### Changed

--- a/lib/canql/grammars/batch_types.treetop
+++ b/lib/canql/grammars/batch_types.treetop
@@ -2,7 +2,7 @@ module Canql
   grammar BatchTypes
     rule batch_type
       (paediatric / enote2 / badger / ucyto / nipt / rddeath /
-      umum / ca_death / biochem / hes / uss) <Nodes::BatchTypeNode>
+      umum / ca_death / biochem / hes / uss / antenatal / postnatal) <Nodes::BatchTypeNode>
     end
 
     rule paediatric
@@ -47,6 +47,14 @@ module Canql
 
     rule ca_death
      ('cadeath' / 'ca death' / 'congenital anomaly death') <Nodes::CADeathNode>
+    end
+
+    rule antenatal
+      'antenatal' <Nodes::AntenatalNode>
+    end
+
+    rule postnatal
+      'postnatal' <Nodes::PostnatalNode>
     end
   end
 end

--- a/lib/canql/nodes/batch_types.rb
+++ b/lib/canql/nodes/batch_types.rb
@@ -74,5 +74,17 @@ module Canql # :nodoc: all
         'ca_death'
       end
     end
+
+    module AntenatalNode
+      def normalise
+        'antenatal'
+      end
+    end
+
+    module PostnatalNode
+      def normalise
+        'postnatal'
+      end
+    end
   end
 end

--- a/lib/canql/version.rb
+++ b/lib/canql/version.rb
@@ -2,5 +2,5 @@
 
 # This stores the current version of the Canql gem
 module Canql
-  VERSION = '6.1.0'
+  VERSION = '7.0.0'
 end

--- a/test/nodes/e_base_records_test.rb
+++ b/test/nodes/e_base_records_test.rb
@@ -222,6 +222,20 @@ class EBaseRecordsTest < Minitest::Test
                  parser.meta_data['unprocessed_records.sources'])
   end
 
+  def test_should_filter_by_unprocessed_antenatal_records
+    parser = Canql::Parser.new('all cases with unprocessed antenatal records')
+    assert parser.valid?
+    assert_equal({ Canql::EQUALS => ['ANTENATAL'] },
+                 parser.meta_data['unprocessed_records.sources'])
+  end
+
+  def test_should_filter_by_unprocessed_postnatal_records
+    parser = Canql::Parser.new('all cases with unprocessed postnatal records')
+    assert parser.valid?
+    assert_equal({ Canql::EQUALS => ['POSTNATAL'] },
+                 parser.meta_data['unprocessed_records.sources'])
+  end
+
   def test_should_filter_on_ebr_specific_processing_date
     parser = Canql::Parser.new('all cases with unprocessed records dated on 20/06/2015')
     assert parser.valid?


### PR DESCRIPTION
- Added new batch types to the grammar and nodes for antenatal and postnatal records.
- Added tests for the new batch types to ensure they are parsed correctly.